### PR TITLE
Add media track stopping

### DIFF
--- a/src/app/src/views/ScreenView.vue
+++ b/src/app/src/views/ScreenView.vue
@@ -147,6 +147,9 @@ export default class ScreenView extends Vue {
   }
 
   moveToScreenSelectView(): void {
+    this.screenStream.getTracks().map((track, index, array) => {
+      track.stop();
+    });
     this.$router.push({ name: "ScreenSelect" });
   }
 


### PR DESCRIPTION
Stop the screen's MediaStreamTrack before return screen select to release "Native desktop capture" WakeLock request.